### PR TITLE
Cleaned up a few warnings from dartanalyzer.

### DIFF
--- a/lib/resource.dart
+++ b/lib/resource.dart
@@ -26,5 +26,7 @@
 /// browser.
 library resource;
 
+import "dart:core" hide Resource;
+
 export "src/io/resource.dart" show Resource;
 export "src/io/loader.dart" show ResourceLoader;

--- a/lib/src/io/io.dart
+++ b/lib/src/io/io.dart
@@ -6,7 +6,6 @@ import "dart:async" show Future, Stream;
 import "dart:convert" show Encoding, LATIN1, UTF8;
 import "dart:io" show
     File, HttpClient, HttpClientResponse, HttpClientRequest, HttpHeaders;
-import "dart:typed_data" show Uint8List;
 
 import "package:typed_data/typed_buffers.dart" show Uint8Buffer;
 


### PR DESCRIPTION
The lib/resource.dart file should hide the deprecated Resource class, and Uint8List isn't needed in lib/src/io/io.dart.