### PR TITLE
Fix bug in `readAsBytes` via http when content-length is set.

### DIFF
--- a/lib/src/io_io.dart
+++ b/lib/src/io_io.dart
@@ -4,13 +4,15 @@
 
 import "dart:async" show Future, Stream;
 import "dart:convert" show Encoding, LATIN1, UTF8;
-import "dart:io" show File,
-                      HttpStatus,
-                      HttpClient,
-                      HttpClientResponse,
-                      HttpClientRequest,
-                      HttpException,
-                      HttpHeaders;
+import "dart:io"
+    show
+        File,
+        HttpStatus,
+        HttpClient,
+        HttpClientResponse,
+        HttpClientRequest,
+        HttpException,
+        HttpHeaders;
 
 import "package:typed_data/typed_buffers.dart" show Uint8Buffer;
 
@@ -43,7 +45,8 @@ Future<List<int>> readAsBytes(Uri uri) async {
     _throwIfFailed(response, uri);
     int length = response.contentLength;
     if (length < 0) length = 0;
-    var buffer = new Uint8Buffer(length);
+    // Create empty buffer with capacity matching contentLength.
+    var buffer = new Uint8Buffer(length)..length = 0;
     await for (var bytes in response) {
       buffer.addAll(bytes);
     }


### PR DESCRIPTION
The `readAsBytes` method returns twice as much data as expected,
with the first half all zeroes. This comes from pre-allocating
the buffer, then appending to it (similar to #21, but with
`readAsBytes` instead of `readAsString`).

Updated the tests to also catch this case.

BUG: #23