### PR TITLE
Cast stream to List<int>

### DIFF
--- a/lib/src/io_io.dart
+++ b/lib/src/io_io.dart
@@ -87,7 +87,7 @@ Future<String> readAsString(Uri uri, Encoding encoding) async {
       var byteList = buffer.buffer.asUint8List(0, buffer.length);
       return new String.fromCharCodes(byteList);
     }
-    return response.transform(encoding.decoder).join();
+    return response.cast<List<int>>().transform(encoding.decoder).join();
   }
   if (uri.scheme == "data") {
     return uri.data.contentAsString(encoding: encoding);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: resource
-version: 2.1.5
+version: 2.1.5+1
 description: Reading resource data from (package and other) files.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/resource


### PR DESCRIPTION
This is in preparation for HttpClientResponse implementing
Stream<Uint8List>.  It is a forwards-compatible change that
should be a no-op for existing usages.

https://github.com/dart-lang/sdk/issues/36900